### PR TITLE
[HGNN-7780] 유니버셜 링크 활성화 시, 카카오 로그인이 되지 않는 문제 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-universal-links-plugin",
-  "version": "1.2.9-hogangnono",
+  "version": "1.2.11-hogangnono",
   "description": "Cordova plugin to add in your application support for Universal Links (iOS 9) and Deep Links (Android). Basically, open application through the link in the browser.",
   "cordova": {
     "id": "cordova-universal-links-plugin",

--- a/plugin.xml
+++ b/plugin.xml
@@ -39,13 +39,19 @@
     </config-file>
     <config-file target="*-Debug.plist" parent="com.apple.developer.associated-domains">
       <array>
+        <string>applinks:local.hogangnono.com</string>
         <string>applinks:dev.hogangnono.com</string>
+        <string>applinks:beta.hogangnono.com</string>
+        <string>applinks:stage.hogangnono.com</string>
         <string>applinks:hogangnono.com</string>
       </array>
     </config-file>
     <config-file target="*-Release.plist" parent="com.apple.developer.associated-domains">
       <array>
+        <string>applinks:local.hogangnono.com</string>
         <string>applinks:dev.hogangnono.com</string>
+        <string>applinks:beta.hogangnono.com</string>
+        <string>applinks:stage.hogangnono.com</string>
         <string>applinks:hogangnono.com</string>
       </array>
     </config-file>


### PR DESCRIPTION
<!--
- PR 제목은 단순 브랜치명이 아닌 작업내용의 대표문구 또는 이슈 제목이 들어가야합니다.
- 필수항목(*) 기재하지 않았을 경우, approve/merge 불가합니다.
- 주석은 내용 숙지 후 제거해도 무방합니다.
-->

# 관련 이슈*
<!-- 지라 링크를 달아주세요. 없을 경우 이슈에 대한 설명을 기재해주세요. -->

https://zigbang.atlassian.net/browse/HGNN-7780

-> ~페이즈 별 앱에 대한 유니버셜 링크 설정이 없어 발생~

# 작업 내용*
<!-- 작업한 내용에 대해 자세하게 설명해주세요. -->

- 추가된 페이즈의 연관 도메인 설정 추가

# 체크리스트*
<!-- 확인해야할 사항을 정리하고 확인해주세요. -->

- [x] PR 모든 항목을 빠짐없이 작성했습니다. (제목, 담당자, 라벨, 마일스톤 등)
- [ ] m/www/app 환경에서 각각 테스트하였습니다.

# 기타
<!-- 기타 공유할 사항이 있다면 설명해주세요. -->

- https://github.com/hogangnono/hogangnono-client/pull/2382
- https://developer.apple.com/documentation/xcode/supporting-associated-domains
