### PR TITLE
Fix for ios prepare

### DIFF
--- a/hooks/lib/ios/xcodePreferences.js
+++ b/hooks/lib/ios/xcodePreferences.js
@@ -145,11 +145,22 @@ function loadProjectFile() {
       platform_ios = context.requireCordovaModule('cordova-lib/src/plugman/platforms/ios');
       projectFile = platform_ios.parse(iosPlatformPath());
     } catch (e) {
-      // try cordova 7.0 structure
-      var iosPlatformApi = require(path.join(iosPlatformPath(), '/cordova/Api'));
-      var projectFileApi = require(path.join(iosPlatformPath(), '/cordova/lib/projectFile.js'));
-      var locations = (new iosPlatformApi()).locations;
-      projectFile = projectFileApi.parse(locations);
+      try {
+        // try cordova 7.0 structure
+        var iosPlatformApi = require(path.join(iosPlatformPath(), '/cordova/Api'));
+        var projectFileApi = require(path.join(iosPlatformPath(), '/cordova/lib/projectFile.js'));
+        var locations = (new iosPlatformApi()).locations;
+        projectFile = projectFileApi.parse(locations);    
+      } catch (e) {
+        // try cordova 7.0.1 structure. This is necessary following the release of
+        // cordova-ios MR 1203, which stopped copying .js files into /lib:
+        // https://github.com/apache/cordova-ios/pull/1203
+        var iosPlatformApi = require('cordova-ios/lib/Api.js');
+        var projectFileApi = require('cordova-ios/lib/projectFile.js');
+        platformApi = new iosPlatformApi("ios", iosPlatformPath());
+        var locations = platformApi.locations;
+        projectFile = projectFileApi.parse(locations);   
+      }  
     }
   }
   return projectFile;

--- a/package.json
+++ b/package.json
@@ -1,51 +1,51 @@
 {
-  "name": "cordova-universal-links-plugin",
-  "version": "1.2.10-hogangnono",
-  "description": "Cordova plugin to add in your application support for Universal Links (iOS 9) and Deep Links (Android). Basically, open application through the link in the browser.",
-  "cordova": {
-    "id": "cordova-universal-links-plugin",
-    "platforms": [
-      "ios",
-      "android"
-    ]
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/hogangnono/cordova-universal-links-plugin.git"
-  },
-  "keywords": [
-    "cordova",
-    "links",
-    "universal",
-    "deep links",
-    "universal links",
-    "ecosystem:cordova",
-    "cordova-ios",
-    "cordova-android",
-    "ios",
-    "android"
-  ],
-  "engines": [
-    {
-      "name": "cordova-ios",
-      "version": ">=3.8"
+    "name": "cordova-universal-links-plugin",
+    "version": "1.2.13-hogangnono",
+    "description": "Cordova plugin to add in your application support for Universal Links (iOS 9) and Deep Links (Android). Basically, open application through the link in the browser.",
+    "cordova": {
+        "id": "cordova-universal-links-plugin",
+        "platforms": [
+            "ios",
+            "android"
+        ]
     },
-    {
-      "name": "cordova-android",
-      "version": ">=4"
-    }
-  ],
-  "dependencies": {
-    "mkpath": ">=1.0.0",
-    "xml2js": "^0.5.0",
-    "rimraf": ">=2.4",
-    "node-version-compare": ">=1.0.1",
-    "plist": ">=1.2.0"
-  },
-  "author": "Hogangnono",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/hogangnono/cordova-universal-links-plugin/issues"
-  },
-  "homepage": "https://github.com/hogangnono/cordova-universal-links-plugin#readme"
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/hogangnono/cordova-universal-links-plugin.git"
+    },
+    "keywords": [
+        "cordova",
+        "links",
+        "universal",
+        "deep links",
+        "universal links",
+        "ecosystem:cordova",
+        "cordova-ios",
+        "cordova-android",
+        "ios",
+        "android"
+    ],
+    "engines": [
+        {
+            "name": "cordova-ios",
+            "version": ">=3.8"
+        },
+        {
+            "name": "cordova-android",
+            "version": ">=4"
+        }
+    ],
+    "dependencies": {
+        "mkpath": ">=1.0.0",
+        "xml2js": "^0.5.0",
+        "rimraf": ">=2.4",
+        "node-version-compare": ">=1.0.1",
+        "plist": ">=1.2.0"
+    },
+    "author": "Hogangnono",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/hogangnono/cordova-universal-links-plugin/issues"
+    },
+    "homepage": "https://github.com/hogangnono/cordova-universal-links-plugin#readme"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<plugin id="cordova-universal-links-plugin" version="1.2.10-hogangnono" xmlns="http://apache.org/cordova/ns/plugins/1.0">
+<plugin id="cordova-universal-links-plugin" version="1.2.13-hogangnono" xmlns="http://apache.org/cordova/ns/plugins/1.0">
 
   <name>Universal Links Plugin</name>
   <description>


### PR DESCRIPTION
# 작업내용
Cordova-ios@7.1 이상에서  hook의 라이브러리를 못찾는 이슈 해결
