### PR TITLE
[fix] com.apple.developer.associated-domains 코드제거 

### DIFF
--- a/hooks/afterPrepareHook.js
+++ b/hooks/afterPrepareHook.js
@@ -76,7 +76,7 @@ function activateUniversalLinksInAndroid(cordovaContext, pluginPreferences) {
 function activateUniversalLinksInIos(cordovaContext, pluginPreferences) {
   console.log('afterPrepareHook activateUniversalLinksInIos');
   // modify xcode project preferences
-  iosProjectPreferences.enableAssociativeDomainsCapability(cordovaContext);
+  //iosProjectPreferences.enableAssociativeDomainsCapability(cordovaContext);
 
   // generate entitlements file
   iosProjectEntitlements.generateAssociatedDomainsEntitlements(cordovaContext, pluginPreferences);

--- a/plugin.xml
+++ b/plugin.xml
@@ -37,18 +37,6 @@
         <param name="onload" value="true"/>
       </feature>
     </config-file>
-    <config-file target="*-Debug.plist" parent="com.apple.developer.associated-domains">
-      <array>
-        <string>applinks:dev.hogangnono.com</string>
-        <string>applinks:hogangnono.com</string>
-      </array>
-    </config-file>
-    <config-file target="*-Release.plist" parent="com.apple.developer.associated-domains">
-      <array>
-        <string>applinks:dev.hogangnono.com</string>
-        <string>applinks:hogangnono.com</string>
-      </array>
-    </config-file>
 
 <!-- Objective-C Sources -->
 


### PR DESCRIPTION
- https://github.com/hogangnono/cordova-universal-links-plugin/pull/5
- com.apple.developer.associated-domains 코드제거 (프로젝트의 config.xml에서 설정해야함)