### PR TITLE
fix(deps): pin plist to ^3.0.0 to avoid ESM-only 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cordova-universal-links-plugin",
-    "version": "1.2.13-hogangnono",
+    "version": "1.2.14-hogangnono",
     "description": "Cordova plugin to add in your application support for Universal Links (iOS 9) and Deep Links (Android). Basically, open application through the link in the browser.",
     "cordova": {
         "id": "cordova-universal-links-plugin",
@@ -40,7 +40,7 @@
         "xml2js": "^0.5.0",
         "rimraf": ">=2.4",
         "node-version-compare": ">=1.0.1",
-        "plist": ">=1.2.0"
+        "plist": "^3.0.0"
     },
     "author": "Hogangnono",
     "license": "MIT",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<plugin id="cordova-universal-links-plugin" version="1.2.13-hogangnono" xmlns="http://apache.org/cordova/ns/plugins/1.0">
+<plugin id="cordova-universal-links-plugin" version="1.2.14-hogangnono" xmlns="http://apache.org/cordova/ns/plugins/1.0">
 
   <name>Universal Links Plugin</name>
   <description>


### PR DESCRIPTION
## Summary

- `plist@5.0.0` (2026-05-03) 부터 ESM-only 로 전환되었고, `package.json` 의 `exports` 에 `require`/`default` 조건이 없어 Node 22 환경에서 CJS `require('plist')` 가 `ERR_PACKAGE_PATH_NOT_EXPORTED` 로 죽는다.
- 이 플러그인의 [hooks/lib/ios/projectEntitlements.js](hooks/lib/ios/projectEntitlements.js) 가 `require('plist')` 를 쓰므로 `cordova prepare` 의 `after_prepare` 훅이 다음과 같이 실패:
  ```
  TypeError [ERR_INVALID_ARG_TYPE]: The "code" argument must be of type number.
  Received type string ('ERR_PACKAGE_PATH_NOT_EXPO...')
      at process.set [as exitCode] (node:internal/bootstrap/node:122:9)
      at /usr/local/lib/node_modules/cordova/bin/cordova:32:22
  ```
  (마지막 TypeError 는 cordova/bin/cordova 가 문자열 err.code 를 `process.exitCode` 에 대입하면서 생기는 부수효과, 진짜 원인은 `ERR_PACKAGE_PATH_NOT_EXPORTED`.)
- 기존 의존성 범위가 `"plist": ">=1.2.0"` 로 major 상한이 없어 `cordova plugin add` 가 latest 5.x 를 박았던 것이 원인. 다른 cordova 플러그인들(custom-config, firebasex)은 이미 `"plist": "^3.0.1"` 로 잡고 있다.

## Changes

- `package.json`: `"plist": ">=1.2.0"` → `"plist": "^3.0.0"` (마지막 CJS 라인)
- version bump: `1.2.13-hogangnono` → `1.2.14-hogangnono`

## Test plan

- [ ] consumer (`hogangnono-phonegap`) 에서 이 fork 의 새 ref 로 plugin 재설치
- [ ] `plugins/cordova-universal-links-plugin/node_modules/plist/package.json` 의 version 이 3.x 인지 확인
- [ ] `node -e "require('cordova-universal-links-plugin/hooks/afterPrepareHook.js')"` 가 throw 없이 통과
- [ ] `cordova prepare android --phase=local` 통과
- [ ] `cordova prepare ios` 통과 (iOS entitlements 생성 정상)

## 참고

- npm plist 릴리스 이력: 3.1.0 (2023-07-06, CJS) → 3.1.1 (2026-04-25, CJS) → 4.0.0 (2026-04-25) → **5.0.0 (2026-05-03, ESM-only)**
- 같은 패턴이 있는 다른 open-ended 의존성(`mkpath`, `rimraf`, `node-version-compare`)도 향후 동일 함정 가능 — 별도 PR 에서 정리 권장 (rimraf 4.x 부터 ESM-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)