### PR TITLE
[HGNN-13889] fix(ios): host project의 CODE_SIGN_ENTITLEMENTS 보존

### DIFF
--- a/hooks/lib/ios/xcodePreferences.js
+++ b/hooks/lib/ios/xcodePreferences.js
@@ -56,10 +56,23 @@ function activateAssociativeDomains(xcodeProject) {
   var config;
   var buildSettings;
   var deploymentTargetIsUpdated;
+  var entitlementsAssigned = false;
+  var entitlementsPreserved = false;
 
   for (config in configurations) {
     buildSettings = configurations[config].buildSettings;
-    buildSettings['CODE_SIGN_ENTITLEMENTS'] = '"' + entitlementsFilePath + '"';
+
+    // Preserve host project's CODE_SIGN_ENTITLEMENTS if already set.
+    // Some projects use per-configuration entitlements files (e.g., Entitlements-Debug.plist,
+    // Entitlements-Release.plist) that carry critical keys like aps-environment.
+    // Overwriting them silently drops those capabilities at sign time. (HGNN-13889)
+    var existing = buildSettings['CODE_SIGN_ENTITLEMENTS'];
+    if (existing && existing !== '""') {
+      entitlementsPreserved = true;
+    } else {
+      buildSettings['CODE_SIGN_ENTITLEMENTS'] = '"' + entitlementsFilePath + '"';
+      entitlementsAssigned = true;
+    }
 
     // if deployment target is less then the required one - increase it
     if (buildSettings['IPHONEOS_DEPLOYMENT_TARGET']) {
@@ -77,7 +90,12 @@ function activateAssociativeDomains(xcodeProject) {
     console.log('IOS project now has deployment target set as: ' + IOS_DEPLOYMENT_TARGET);
   }
 
-  console.log('IOS project Code Sign Entitlements now set to: ' + entitlementsFilePath);
+  if (entitlementsAssigned) {
+    console.log('IOS project Code Sign Entitlements now set to: ' + entitlementsFilePath);
+  }
+  if (entitlementsPreserved) {
+    console.log('IOS project Code Sign Entitlements already configured; preserving existing value.');
+  }
 }
 
 // endregion

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cordova-universal-links-plugin",
-    "version": "1.2.14-hogangnono",
+    "version": "1.2.15-hogangnono",
     "description": "Cordova plugin to add in your application support for Universal Links (iOS 9) and Deep Links (Android). Basically, open application through the link in the browser.",
     "cordova": {
         "id": "cordova-universal-links-plugin",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<plugin id="cordova-universal-links-plugin" version="1.2.14-hogangnono" xmlns="http://apache.org/cordova/ns/plugins/1.0">
+<plugin id="cordova-universal-links-plugin" version="1.2.15-hogangnono" xmlns="http://apache.org/cordova/ns/plugins/1.0">
 
   <name>Universal Links Plugin</name>
   <description>


### PR DESCRIPTION
# 관련 이슈*

https://zigbang.atlassian.net/browse/HGNN-13889

# 작업 내용*

## 문제

`hooks/lib/ios/xcodePreferences.js`의 `activateAssociativeDomains()`가 모든 build configuration의 `CODE_SIGN_ENTITLEMENTS`를 자기 entitlements 파일로 무조건 덮어쓰면서, 호스트 프로젝트가 자체 관리하는 per-configuration entitlements(`Entitlements-Debug.plist` / `Entitlements-Release.plist`)가 사이닝에서 떨어져 나가는 회귀 발생.

결과적으로 `aps-environment` 등 호스트의 필수 capability가 빌드 산출물에 누락되어 APNs 등록 실패(Code 3000) → FCM 토큰 발급 실패(Code 505)로 이어짐.

## 변경

`activateAssociativeDomains()`에 **기존 값 보존 가드** 추가:

- 호스트가 이미 `CODE_SIGN_ENTITLEMENTS`를 설정해뒀으면 → 보존
- 빈 슬롯이면 → 기존처럼 plugin이 자기 파일을 가리키도록 설정 (기존 동작 유지)

버전: `1.2.14-hogangnono` → `1.2.15-hogangnono`

# 체크리스트*

- [x] PR 모든 항목을 빠짐없이 작성했습니다. (제목, 담당자, 라벨 등)
- [ ] 호스트 프로젝트(hogangnono-phonegap)에 적용 후 빌드 산출물에서 `aps-environment` 키 존재 확인
- [ ] 실기기에서 APNs 등록 성공 + FCM 토큰 발급 확인

# 기타

- 새 cordova 프로젝트(entitlements 미관리)에서는 기존 동작 그대로 유지됨.
- 머지/publish 후 호스트에서 `unpinUniversalLinksEsmPlist()` 우회 코드(PR 275 #da9cfe9)도 제거 가능 — 별도 PR로 청소 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)